### PR TITLE
Remove email 2FA and fix lossy session-cookie persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-05-30
+
+### Breaking
+
+- **Removed `TwoFactorMode.EMAIL`.** Empower no longer offers email as a 2FA
+  delivery method — the login screen presents only SMS (and voice call), and
+  the legacy `challengeEmail` endpoint returns success while dispatching no
+  email. `TwoFactorMode` now has a single member, `SMS`. Code that referenced
+  `TwoFactorMode.EMAIL` must use `TwoFactorMode.SMS`.
+
+### Fixed
+
+- **Spurious "Session not authenticated" on the first request after a
+  successful login.** Sessions were saved as a domain-less `{name: value}`
+  cookie dump, so a reloaded cookie no longer collided with the fresh cookie
+  the server set during the next login — both ended up in the jar and the
+  stale one shadowed the fresh one, which Empower rejected. Cookies are now
+  persisted with their `domain`/`path`/`expires`, so the fresh login cookie
+  overwrites the stale one by key. This also lets a remembered device survive
+  across runs instead of re-triggering 2FA every time.
+- **Email 2FA failed silently.** Selecting email dispatched a challenge that
+  never arrived and then blocked waiting for a code; it now errors clearly
+  (see below) instead of hanging.
+
+### Changed
+
+- **`EMPOWER_2FA_MODE` accepts `sms` only and is now optional** — 2FA defaults
+  to SMS when unset (there is no longer a method to choose). A stale `email`
+  value raises a clear `EmpowerAuthError` pointing to SMS rather than a generic
+  "invalid mode" error. The interactive 2FA-method prompt has been removed.
+- **Session file format.** Cookies are stored as a list of objects with full
+  attributes (schema `version: 2`). Pre-0.4.0 files are ignored on load and the
+  client re-authenticates once, rewriting the file in the new format — the
+  session file is a short-lived cache, so no migration is performed.
+- Documentation no longer claims a fixed "6-digit" verification code length
+  (Empower's SMS code is shorter); wording is now length-agnostic.
+
 ## [0.3.0] — 2026-04-29
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,23 +49,25 @@ print(f"Net cashflow: ${result.summary.net_cashflow:,.2f}")
 |---|---|
 | `EMPOWER_EMAIL` | Empower account email |
 | `EMPOWER_PASSWORD` | Empower account password |
-| `EMPOWER_2FA_MODE` | `sms` or `email` — skips the interactive 2FA-method prompt (read only when 2FA is required) |
+| `EMPOWER_2FA_MODE` | `sms` (the only method Empower still offers) — optional; 2FA defaults to SMS |
 | `PC2_SESSION_PATH` | Custom session file location (default: `~/.config/personalcapital2/session.json`) |
 
 Credentials go to Empower over HTTPS only — never stored, logged, or transmitted elsewhere.
 
-Sessions live ~24 hours. Set `EMPOWER_EMAIL` and `EMPOWER_PASSWORD` (and `EMPOWER_2FA_MODE` if 2FA may fire) so commands self-heal when a session expires; otherwise re-run `pc2 login`. Override the session path per-command with `--session`.
+> **Note:** Empower removed email 2FA — verification codes are sent by SMS only. `EMPOWER_2FA_MODE` is kept for compatibility but now only accepts `sms`; a stale `email` value raises a clear error pointing you to SMS.
+
+Sessions live ~24 hours. Set `EMPOWER_EMAIL` and `EMPOWER_PASSWORD` so commands self-heal when a session expires; otherwise re-run `pc2 login`. Override the session path per-command with `--session`.
 
 #### Headless authentication
 
 For unattended invocation, pipe the verification code on stdin:
 
 ```bash
-EMPOWER_EMAIL=... EMPOWER_PASSWORD=... EMPOWER_2FA_MODE=sms \
+EMPOWER_EMAIL=... EMPOWER_PASSWORD=... \
     printf '%s\n' "$CODE" | pc2 login
 ```
 
-The orchestrator handles SMS/email pickup; `pc2` reads the code from stdin.
+The orchestrator handles SMS code pickup; `pc2` reads the code from stdin.
 
 ## CLI
 
@@ -121,15 +123,14 @@ Client config (Claude Code / Claude Desktop):
       "env": {
         "PC2_SESSION_PATH": "~/.config/personalcapital2/session.json",
         "EMPOWER_EMAIL": "you@example.com",
-        "EMPOWER_PASSWORD": "...",
-        "EMPOWER_2FA_MODE": "sms"
+        "EMPOWER_PASSWORD": "..."
       }
     }
   }
 }
 ```
 
-When the cached session expires mid-conversation, the agent recovers in chat without dropping to a terminal: it calls `start_authentication`, asks you for the 6-digit code, then calls `complete_authentication` with the code. The server reads the credentials and `EMPOWER_2FA_MODE` from this env block.
+When the cached session expires mid-conversation, the agent recovers in chat without dropping to a terminal: it calls `start_authentication`, asks you for the SMS verification code, then calls `complete_authentication` with the code. The server reads the credentials from this env block.
 
 > Note: `EMPOWER_PASSWORD` sits plaintext in the MCP client config — standard pattern for MCP servers, but worth knowing.
 
@@ -144,4 +145,4 @@ This library uses Empower's unofficial internal web API, which is not affiliated
 - **`get_accounts` may not list all accounts with holdings.** Some accounts (employer 401k plans, crypto exchanges) can appear in `get_holdings`, `get_account_balances`, and `get_performance` but not in `get_accounts`. Use `get_holdings` to discover investment account IDs.
 - **Fee fields can be `NaN`.** The API returns `"NaN"` for `fees_per_year`, `fund_fees`, `total_fee`, and `advisory_fee_percentage` on some investment accounts (401k plans, crypto, RSUs). These are coerced to `None` — the account is not dropped.
 - **`get_spending` ignores date range and interval.** The API always returns current-period spending for all three interval types (MONTH, WEEK, YEAR), regardless of the `start_date`, `end_date`, or `interval` parameters.
-- **Sessions expire.** Typically ~24 hours, sometimes sooner. CLI users run `pc2 login` again; MCP users let the agent call `start_authentication` / `complete_authentication`. Stale-session recovery handles this automatically when `EMPOWER_EMAIL`/`EMPOWER_PASSWORD` (and `EMPOWER_2FA_MODE` if needed) are set.
+- **Sessions expire.** Typically ~24 hours, sometimes sooner. CLI users run `pc2 login` again; MCP users let the agent call `start_authentication` / `complete_authentication`. Stale-session recovery handles this automatically when `EMPOWER_EMAIL`/`EMPOWER_PASSWORD` are set.

--- a/docs/api.md
+++ b/docs/api.md
@@ -114,7 +114,7 @@ If `EMPOWER_EMAIL`/`EMPOWER_PASSWORD` aren't set, recovery prompts for credentia
 
 ## Headless library use
 
-`authenticate()` is a TTY-friendly convenience wrapper. Library callers wanting full control over credential sourcing and 2FA pickup — for example, an agent that retrieves the verification code from an SMS provider or IMAP inbox — can skip `authenticate()` and call the lower-level `EmpowerClient` methods directly.
+`authenticate()` is a TTY-friendly convenience wrapper. Library callers wanting full control over credential sourcing and 2FA pickup — for example, an agent that retrieves the SMS verification code from an SMS provider — can skip `authenticate()` and call the lower-level `EmpowerClient` methods directly.
 
 ```python
 from pathlib import Path

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -43,7 +43,7 @@ pc2 mcp
 |---|---|
 | `EMPOWER_EMAIL` | Empower account email (skips the email prompt) |
 | `EMPOWER_PASSWORD` | Empower account password (skips the password prompt). Setting both `EMPOWER_EMAIL` and `EMPOWER_PASSWORD` lets stale-session recovery run without prompting mid-command. |
-| `EMPOWER_2FA_MODE` | `sms` or `email` (case-insensitive). Skips the interactive method-selection prompt when 2FA is required. Empty/whitespace is treated as unset; an invalid value raises `EmpowerAuthError`. Read lazily — only consulted when the server actually requires 2FA, so a leftover value doesn't break flows where the device is remembered. |
+| `EMPOWER_2FA_MODE` | `sms` (case-insensitive) — the only method Empower still offers. Optional: 2FA defaults to SMS when unset. Empower removed email 2FA, so a stale `email` value raises a clear `EmpowerAuthError` pointing to SMS; any other value also raises `EmpowerAuthError`. Read lazily — only consulted when the server actually requires 2FA, so a leftover value doesn't break flows where the device is remembered. |
 | `PC2_SESSION_PATH` | Override the default session file path (default: `~/.config/personalcapital2/session.json`). Per-command override: `--session PATH`. |
 | `PC2_MCP_MAX_CHARS` | MCP-server-only. Soft cap on tool response size in characters (default: 50,000 ≈ 12,500 tokens). Lists are truncated with `truncated` metadata before exceeding the cap. |
 
@@ -51,14 +51,14 @@ pc2 mcp
 
 If the cached session is rejected by Empower mid-command, `pc2` re-authenticates and retries the request once. Set `EMPOWER_EMAIL` and `EMPOWER_PASSWORD` to avoid a mid-command credential prompt during recovery.
 
-For fully headless invocation when 2FA may be required, also set `EMPOWER_2FA_MODE` and pipe the verification code on stdin:
+For fully headless invocation when 2FA may be required, pipe the verification code on stdin:
 
 ```bash
-EMPOWER_EMAIL=... EMPOWER_PASSWORD=... EMPOWER_2FA_MODE=sms \
+EMPOWER_EMAIL=... EMPOWER_PASSWORD=... \
     printf '%s\n' "$CODE" | pc2 login
 ```
 
-The orchestrator owns SMS/email pickup — pc2 reads the code from stdin. Without `EMPOWER_2FA_MODE`, the 2FA-method prompt would block in a non-TTY environment and fail with `InteractiveAuthRequired`.
+The orchestrator owns SMS code pickup — pc2 reads the code from stdin. 2FA defaults to SMS, so there's no method prompt to block on in a non-TTY environment; only the verification-code prompt needs the piped code (otherwise it raises `InteractiveAuthRequired`).
 
 ## Exit codes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "personalcapital2"
-version = "0.3.0"
+version = "0.4.0"
 description = "Python client for the Empower (Personal Capital) unofficial API"
 readme = "README.md"
 license = "MIT"

--- a/src/personalcapital2/auth.py
+++ b/src/personalcapital2/auth.py
@@ -46,8 +46,11 @@ def parse_2fa_mode_env(value: str) -> TwoFactorMode:
     if value == "sms":
         return TwoFactorMode.SMS
     if value == "email":
-        return TwoFactorMode.EMAIL
-    raise EmpowerAuthError(f"Invalid EMPOWER_2FA_MODE={value!r}: must be 'sms' or 'email'")
+        # Tombstone: Empower removed email 2FA server-side (the challengeEmail
+        # endpoint now returns success but dispatches nothing). Point stale
+        # config at the working method instead of a generic "invalid" error.
+        raise EmpowerAuthError("Empower no longer supports email 2FA — set EMPOWER_2FA_MODE=sms")
+    raise EmpowerAuthError(f"Invalid EMPOWER_2FA_MODE={value!r}: must be 'sms'")
 
 
 def authenticate(session_path: Path = DEFAULT_SESSION_PATH) -> EmpowerClient:
@@ -101,30 +104,21 @@ def authenticate(session_path: Path = DEFAULT_SESSION_PATH) -> EmpowerClient:
         # Read EMPOWER_2FA_MODE inside this branch (not eagerly) so an
         # invalid value lying around in the environment doesn't break flows
         # where the device is already remembered and 2FA isn't triggered.
+        # SMS is the only method Empower still offers, so there's no method
+        # prompt — a set value is validated (a stale 'email' gets a clear
+        # tombstone error), otherwise we default to SMS.
         env_mode = os.environ.get("EMPOWER_2FA_MODE", "").strip().lower()
-        if env_mode:
-            mode = parse_2fa_mode_env(env_mode)
-        else:
-            try:
-                print("\n2FA required. Choose method:", file=sys.stderr)
-                print("  1. SMS", file=sys.stderr)
-                print("  2. Email", file=sys.stderr)
-                choice = _prompt("Choice [1]: ").strip() or "1"
-            except EOFError:
-                raise InteractiveAuthRequired(
-                    "2FA mode prompt cannot complete without an interactive "
-                    "terminal. Set EMPOWER_2FA_MODE=sms or email and pipe the "
-                    "6-digit verification code on stdin for headless use."
-                ) from None
-            mode = TwoFactorMode.SMS if choice == "1" else TwoFactorMode.EMAIL
+        mode = parse_2fa_mode_env(env_mode) if env_mode else TwoFactorMode.SMS
+        print("\n2FA required — sending SMS verification code.", file=sys.stderr)
         client.send_2fa_challenge(mode)
         return client, mode
 
     try:
         client, mode = _login_and_maybe_challenge()
     except InteractiveAuthRequired:
-        # Non-TTY at the 2FA-method prompt is NOT a stale-session problem.
-        # Re-raise without unlinking — preserve the user's cached session.
+        # InteractiveAuthRequired subclasses EmpowerAuthError; catch it first so
+        # a "no TTY" signal is never mistaken for stale cookies and never
+        # triggers a session unlink. Re-raise as-is, preserving the cached session.
         raise
     except EmpowerAuthError:
         # Stale cached cookies. Clear and retry once with a fresh client.

--- a/src/personalcapital2/client.py
+++ b/src/personalcapital2/client.py
@@ -22,10 +22,11 @@ import re
 from datetime import date
 from decimal import Decimal
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import requests
 from requests.adapters import HTTPAdapter
+from requests.cookies import RequestsCookieJar
 from urllib3.util.retry import Retry
 
 from personalcapital2.exceptions import (
@@ -176,7 +177,7 @@ class EmpowerClient:
         # Retry transient HTTP errors with exponential backoff.
         # POST is included because Empower uses POST for all endpoints,
         # including read-only data queries. The only non-idempotent POSTs
-        # are 2FA challenge endpoints (SMS/email), but retries are limited
+        # are 2FA challenge endpoints (SMS), but retries are limited
         # to server errors (5xx/429) where the original request likely
         # failed before any side effects.
         retry = Retry(
@@ -252,7 +253,7 @@ class EmpowerClient:
         self._authenticate_password(password)
 
     def send_2fa_challenge(self, mode: TwoFactorMode) -> None:
-        """Send a 2FA challenge (SMS or email) without completing the flow."""
+        """Send a 2FA challenge (SMS) without completing the flow."""
         self._send_2fa_challenge(mode)
 
     def verify_2fa_and_login(self, mode: TwoFactorMode, code: str, password: str) -> None:
@@ -482,6 +483,14 @@ class EmpowerClient:
     def save_session(self, path: Path | None = None) -> None:
         """Save session cookies and CSRF token to a JSON file (chmod 600).
 
+        Persists each cookie's ``domain``/``path``/``expires`` (not just
+        name=value). Dropping the domain — as a plain ``{name: value}`` dump
+        does — makes a reloaded cookie domain-less, so it no longer collides
+        with the fresh cookie the server sets on the next login: both end up in
+        the jar and the stale one shadows the fresh one, which the server
+        rejects ("Session not authenticated"). Preserving the domain lets the
+        next login's Set-Cookie overwrite the stale cookie by key.
+
         Uses atomic write (write to temp file, then rename) to prevent
         corrupt or world-readable session files on crash.
         """
@@ -491,10 +500,19 @@ class EmpowerClient:
 
         target.parent.mkdir(parents=True, exist_ok=True)
 
-        cookies: dict[str, str] = requests.utils.dict_from_cookiejar(  # type: ignore[no-untyped-call] — requests.utils is untyped
-            self._session.cookies
-        )
-        session_data: dict[str, str | dict[str, str]] = {
+        cookies: list[dict[str, Any]] = [
+            {
+                "name": c.name,
+                "value": c.value,
+                "domain": c.domain,
+                "path": c.path,
+                "expires": c.expires,
+                "secure": c.secure,
+            }
+            for c in self._session.cookies
+        ]
+        session_data: dict[str, Any] = {
+            "version": 2,
             "csrf": self._csrf,
             "cookies": cookies,
         }
@@ -536,7 +554,7 @@ class EmpowerClient:
         try:
             data = json.loads(self._session_path.read_text())
             csrf = data.get("csrf", "")
-            cookies = data.get("cookies", {})
+            cookies = data.get("cookies")
             if not csrf and not cookies:
                 # An empty/malformed session file silently produced an unauthenticated
                 # client that later failed with a confusing "Session is no longer valid".
@@ -547,11 +565,38 @@ class EmpowerClient:
                     self._session_path,
                 )
                 return
+            if not isinstance(cookies, list):
+                # Pre-0.4.0 format stored cookies as a domain-less {name: value}
+                # dict. Reloading those caused stale cookies to shadow fresh ones
+                # ("Session not authenticated"). The session file is a disposable
+                # cache, so don't resurrect them — ignore and re-authenticate. The
+                # next save_session() rewrites the file in the current format.
+                log.info(
+                    "Session file %s uses an old format; re-authenticating",
+                    self._session_path,
+                )
+                return
+            jar = RequestsCookieJar()
+            # json.loads returns Any; isinstance() above narrows it to a list
+            # with Unknown elements, so name the entry type explicitly. The
+            # individual reads below are validated at runtime by the except clause.
+            for c in cast("list[dict[str, Any]]", cookies):
+                # requests' RequestsCookieJar.set stub types **kwargs as Unknown.
+                jar.set(  # type: ignore[reportUnknownMemberType]
+                    c["name"],
+                    c["value"],
+                    domain=c.get("domain", ""),
+                    path=c.get("path", "/"),
+                    expires=c.get("expires"),
+                    secure=c.get("secure", False),
+                )
             self._csrf = csrf
-            self._session.cookies = requests.utils.cookiejar_from_dict(cookies)  # type: ignore[no-untyped-call] — requests.utils is untyped
+            # Assign (replace) rather than merge: mcp_server._get_client reloads on
+            # every call and relies on a stale-cookie-free jar after re-auth.
+            self._session.cookies = jar
             self._loaded_from_disk = True
             log.info("Loaded session from %s", self._session_path)
-        except (json.JSONDecodeError, KeyError, ValueError, AttributeError) as err:
+        except (json.JSONDecodeError, KeyError, ValueError, AttributeError, TypeError) as err:
             log.warning("Could not load session: %s", err)
 
     # --- Private Methods ---
@@ -688,14 +733,12 @@ class EmpowerClient:
             self._csrf = header["csrf"]
 
     def _send_2fa_challenge(self, mode: TwoFactorMode) -> None:
-        """Request a 2FA code via SMS or email."""
+        """Request a 2FA code via SMS."""
         endpoints = {
             TwoFactorMode.SMS: "/credential/challengeSms",
-            TwoFactorMode.EMAIL: "/credential/challengeEmail",
         }
         challenge_types = {
             TwoFactorMode.SMS: "challengeSMS",
-            TwoFactorMode.EMAIL: "challengeEmail",
         }
         data = {
             "challengeReason": "DEVICE_AUTH",
@@ -734,7 +777,6 @@ class EmpowerClient:
         """Submit the 2FA verification code."""
         endpoints = {
             TwoFactorMode.SMS: "/credential/authenticateSms",
-            TwoFactorMode.EMAIL: "/credential/authenticateEmailByCode",
         }
         data = {
             "challengeReason": "DEVICE_AUTH",

--- a/src/personalcapital2/mcp_server.py
+++ b/src/personalcapital2/mcp_server.py
@@ -17,8 +17,7 @@ Client config (Claude Code / Claude Desktop):
                 "env": {
                     "PC2_SESSION_PATH": "~/.config/personalcapital2/session.json",
                     "EMPOWER_EMAIL": "you@example.com",
-                    "EMPOWER_PASSWORD": "...",
-                    "EMPOWER_2FA_MODE": "sms"
+                    "EMPOWER_PASSWORD": "..."
                 }
             }
         }
@@ -44,8 +43,6 @@ import requests
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from personalcapital2.types import TwoFactorMode
 from mcp.server.fastmcp import Context, FastMCP
 
 from personalcapital2._serialization import serialize_result
@@ -57,6 +54,7 @@ from personalcapital2.exceptions import (
     EmpowerNetworkError,
     TwoFactorRequiredError,
 )
+from personalcapital2.types import TwoFactorMode
 
 log = logging.getLogger(__name__)
 
@@ -226,8 +224,8 @@ def _handle_tool_errors[**P](fn: Callable[P, str]) -> Callable[P, str]:
             return (
                 f"Error: {exc}\n\n"
                 "Session is expired or invalid. Call start_authentication to "
-                "begin re-auth, then complete_authentication with the 6-digit "
-                "code if 2FA is required."
+                "begin re-auth, then complete_authentication with the "
+                "verification code if 2FA is required."
             )
         except EmpowerNetworkError as exc:
             log.warning("Network error in tool call: %s", exc)
@@ -248,16 +246,14 @@ def _handle_tool_errors[**P](fn: Callable[P, str]) -> Callable[P, str]:
 def start_authentication(ctx: Context) -> str:
     """Re-authenticate when the cached session is stale.
 
-    Reads EMPOWER_EMAIL, EMPOWER_PASSWORD, and (if 2FA required)
-    EMPOWER_2FA_MODE from the MCP server's environment. If the device
-    is remembered, completes authentication directly. Otherwise dispatches
-    a 2FA challenge via SMS or email; call complete_authentication next
-    with the 6-digit code.
+    Reads EMPOWER_EMAIL and EMPOWER_PASSWORD from the MCP server's
+    environment. If the device is remembered, completes authentication
+    directly. Otherwise dispatches a 2FA challenge via SMS; call
+    complete_authentication next with the verification code.
 
-    Each call that hits the 2FA branch dispatches a fresh SMS or email —
-    call sparingly to avoid spamming the user. State is process-local;
-    if the MCP server restarts mid-flow, call this again to begin a new
-    challenge.
+    Each call that hits the 2FA branch dispatches a fresh SMS — call
+    sparingly to avoid spamming the user. State is process-local; if the
+    MCP server restarts mid-flow, call this again to begin a new challenge.
     """
     app_ctx: _AppContext = ctx.request_context.lifespan_context
     email = os.getenv("EMPOWER_EMAIL")
@@ -277,15 +273,12 @@ def start_authentication(ctx: Context) -> str:
     try:
         fresh_client.login(email, password)
     except TwoFactorRequiredError:
+        # SMS is the only method Empower offers, so EMPOWER_2FA_MODE is
+        # optional and defaults to SMS; a stale 'email' value still gets a
+        # clear tombstone error from parse_2fa_mode_env.
         env_mode = os.getenv("EMPOWER_2FA_MODE", "").strip().lower()
-        if not env_mode:
-            return (
-                "Error: 2FA required but EMPOWER_2FA_MODE not set. "
-                "Add EMPOWER_2FA_MODE='sms' or 'email' to the env block "
-                "and restart."
-            )
         try:
-            mode = parse_2fa_mode_env(env_mode)
+            mode = parse_2fa_mode_env(env_mode) if env_mode else TwoFactorMode.SMS
         except EmpowerAuthError as exc:
             return f"Error: {exc}"
         try:
@@ -303,7 +296,7 @@ def start_authentication(ctx: Context) -> str:
         app_ctx.pending_2fa_mode = mode
         return (
             f"2FA challenge sent via {mode.value}. "
-            "Call complete_authentication with the 6-digit code."
+            "Call complete_authentication with the verification code."
         )
     except EmpowerNetworkError as exc:
         return f"Error: network failure during login — {exc}. Check connection and try again."
@@ -321,10 +314,10 @@ def start_authentication(ctx: Context) -> str:
 
 
 def complete_authentication(ctx: Context, code: str) -> str:
-    """Submit the 6-digit 2FA code to complete authentication.
+    """Submit the 2FA verification code to complete authentication.
 
     Call this after start_authentication has dispatched a 2FA challenge.
-    Pass the 6-digit code that was sent to the user's phone or email.
+    Pass the verification code that was sent to the user's phone via SMS.
     """
     app_ctx: _AppContext = ctx.request_context.lifespan_context
     if app_ctx.pending_2fa_mode is None:
@@ -389,7 +382,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
     #
     # Two tools (not one stateful tool) for LLM ergonomics: each has a single
     # clear purpose. State (pending_2fa_mode) lives on _AppContext so the
-    # 6-digit code can be collected from the user mid-conversation.
+    # verification code can be collected from the user mid-conversation.
     #
     # These deliberately do NOT use @_handle_tool_errors — that decorator
     # would direct callers BACK to start_authentication on EmpowerAuthError,
@@ -419,7 +412,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if the session is expired — call
         start_authentication to begin re-auth, then complete_authentication
-        with the 6-digit code if 2FA is required.
+        with the verification code if 2FA is required.
         """
         client = _get_client(ctx)
         result = client.get_accounts()
@@ -443,7 +436,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if start_date is after end_date,
         or if the session is expired — in which case call start_authentication
-        to begin re-auth, then complete_authentication with the 6-digit code
+        to begin re-auth, then complete_authentication with the verification code
         if 2FA is required.
         """
         if err := _validate_date_range(start_date, end_date):
@@ -471,7 +464,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if the session is expired — call
         start_authentication to begin re-auth, then complete_authentication
-        with the 6-digit code if 2FA is required.
+        with the verification code if 2FA is required.
         """
         if limit < 1:
             return "Error: limit must be at least 1."
@@ -499,7 +492,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if start_date is after end_date,
         or if the session is expired — in which case call start_authentication
-        to begin re-auth, then complete_authentication with the 6-digit code
+        to begin re-auth, then complete_authentication with the verification code
         if 2FA is required.
         """
         if err := _validate_date_range(start_date, end_date):
@@ -532,7 +525,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if start_date is after end_date,
         or if the session is expired — in which case call start_authentication
-        to begin re-auth, then complete_authentication with the 6-digit code
+        to begin re-auth, then complete_authentication with the verification code
         if 2FA is required.
         """
         if err := _validate_date_range(start_date, end_date):
@@ -575,7 +568,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if start_date is after end_date,
         or if the session is expired — in which case call start_authentication
-        to begin re-auth, then complete_authentication with the 6-digit code
+        to begin re-auth, then complete_authentication with the verification code
         if 2FA is required.
         """
         if err := _validate_date_range(start_date, end_date):
@@ -603,7 +596,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if start_date is after end_date,
         or if the session is expired — in which case call start_authentication
-        to begin re-auth, then complete_authentication with the 6-digit code
+        to begin re-auth, then complete_authentication with the verification code
         if 2FA is required.
         """
         if err := _validate_date_range(start_date, end_date):
@@ -637,7 +630,7 @@ def create_server(session_path: Path | None = None) -> FastMCP:
 
         Errors: returns an error message if the session is expired — call
         start_authentication to begin re-auth, then complete_authentication
-        with the 6-digit code if 2FA is required.
+        with the verification code if 2FA is required.
         """
         today = date.today()
         effective_start = start_date or today

--- a/src/personalcapital2/types.py
+++ b/src/personalcapital2/types.py
@@ -5,4 +5,3 @@ from enum import Enum
 
 class TwoFactorMode(Enum):
     SMS = "SMS"
-    EMAIL = "EMAIL"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,9 +498,10 @@ def test_snapshot_help_shows_format_behavior(capsys: pytest.CaptureFixture[str])
 def _create_session(tmp_path: Path) -> Path:
     """Create a valid session file and return its path."""
     session_path = tmp_path / "session.json"
-    session_data: dict[str, str | dict[str, str]] = {
+    session_data: dict[str, object] = {
+        "version": 2,
         "csrf": "test-csrf-token",
-        "cookies": {},
+        "cookies": [],
     }
     session_path.write_text(json.dumps(session_data))
     session_path.chmod(0o600)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -363,7 +363,7 @@ def test_2fa_challenge_failure_raises() -> None:
         patch.object(client._session, "request", return_value=challenge_resp),
         pytest.raises(EmpowerAuthError, match="Session no longer valid"),
     ):
-        client.send_2fa_challenge(TwoFactorMode.EMAIL)
+        client.send_2fa_challenge(TwoFactorMode.SMS)
 
 
 # --- User-Agent configurability ---
@@ -448,3 +448,61 @@ def test_request_lets_http_error_propagate() -> None:
         pytest.raises(requests.HTTPError),
     ):
         client._request("GET", "https://example.invalid/")
+
+
+# --- Session persistence (cookie round-trip / shadowing) ---
+
+
+def test_session_round_trip_preserves_cookie_attributes(tmp_path: Path) -> None:
+    """save_session/load_session preserve a cookie's domain and path, so a
+    reloaded cookie keys identically to the one the server set."""
+    session_path = tmp_path / "session.json"
+    client = EmpowerClient(session_path=session_path)
+    client._csrf = "csrf-1"
+    client._session.cookies.set(  # pyright: ignore[reportUnknownMemberType]
+        "JSESSIONID", "abc", domain=".empower-retirement.com", path="/"
+    )
+    client.save_session()
+
+    fresh = EmpowerClient(session_path=session_path)  # loads in __init__
+    loaded = [c for c in fresh._session.cookies if c.name == "JSESSIONID"]
+    assert len(loaded) == 1
+    assert loaded[0].value == "abc"
+    assert loaded[0].domain == ".empower-retirement.com"
+    assert loaded[0].path == "/"
+    assert fresh._csrf == "csrf-1"
+    assert fresh.has_loaded_session is True
+
+
+def test_reloaded_cookie_is_overwritten_not_shadowed(tmp_path: Path) -> None:
+    """Regression for the 'Session not authenticated' bug: a reloaded cookie
+    must be overwritten by a fresh same-name cookie on the same domain, not
+    coexist with it. The old domain-less format kept both and the stale one
+    shadowed the fresh one, so the server rejected the data call."""
+    session_path = tmp_path / "session.json"
+    client = EmpowerClient(session_path=session_path)
+    client._session.cookies.set(  # pyright: ignore[reportUnknownMemberType]
+        "JSESSIONID", "stale", domain=".empower-retirement.com", path="/"
+    )
+    client.save_session()
+
+    fresh = EmpowerClient(session_path=session_path)
+    # Server issues a fresh cookie of the same name/domain on the next login.
+    fresh._session.cookies.set(  # pyright: ignore[reportUnknownMemberType]
+        "JSESSIONID", "new", domain=".empower-retirement.com", path="/"
+    )
+    values = [c.value for c in fresh._session.cookies if c.name == "JSESSIONID"]
+    assert values == ["new"], f"expected only the fresh cookie, got {values}"
+
+
+def test_old_format_session_file_is_ignored(tmp_path: Path) -> None:
+    """A pre-0.4.0 {name: value} dict session file is ignored (triggers
+    re-auth) rather than resurrecting domain-less cookies that would shadow
+    fresh ones."""
+    session_path = tmp_path / "session.json"
+    session_path.write_text(json.dumps({"csrf": "x", "cookies": {"JSESSIONID": "stale"}}))
+    session_path.chmod(0o600)
+
+    client = EmpowerClient(session_path=session_path)
+    assert client.has_loaded_session is False
+    assert list(client._session.cookies) == []

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -323,7 +323,7 @@ def mock_client() -> MagicMock:
 def session_file(tmp_path: Path) -> Path:
     """Create a fake session file."""
     f = tmp_path / "session.json"
-    f.write_text('{"csrf": "test", "cookies": {}}')
+    f.write_text('{"version": 2, "csrf": "test", "cookies": []}')
     f.chmod(0o600)
     return f
 
@@ -1437,19 +1437,44 @@ def test_start_authentication_missing_credentials(
     assert _FakeAuthClient.instances == []
 
 
-def test_start_authentication_2fa_required_but_mode_unset(
+def test_start_authentication_2fa_required_mode_unset_defaults_to_sms(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     auth_env: None,
     patch_auth_client: None,
 ) -> None:
+    """With EMPOWER_2FA_MODE unset, 2FA defaults to SMS — the only method
+    Empower offers — instead of erroring."""
     monkeypatch.delenv("EMPOWER_2FA_MODE", raising=False)
     app_ctx = _make_app_ctx(tmp_path)
     _FakeAuthClient.login_recipe = [TwoFactorRequiredError()]
 
     result = start_authentication(_make_ctx(app_ctx))
 
-    assert "EMPOWER_2FA_MODE" in result
+    assert "complete_authentication" in result
+    assert "SMS" in result
+    assert app_ctx.pending_2fa_mode is _TwoFactorMode.SMS
+    fresh = _FakeAuthClient.instances[0]
+    assert fresh.send_2fa_modes == [_TwoFactorMode.SMS]
+
+
+def test_start_authentication_2fa_mode_email_tombstone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    auth_env: None,
+    patch_auth_client: None,
+) -> None:
+    """A stale EMPOWER_2FA_MODE=email returns a clear tombstone error (Empower
+    removed email 2FA) rather than dispatching a challenge that never arrives."""
+    monkeypatch.setenv("EMPOWER_2FA_MODE", "email")
+    app_ctx = _make_app_ctx(tmp_path)
+    _FakeAuthClient.login_recipe = [TwoFactorRequiredError()]
+
+    result = start_authentication(_make_ctx(app_ctx))
+
+    assert "Error" in result
+    assert "email" in result.lower()
+    assert "sms" in result.lower()
     assert app_ctx.pending_2fa_mode is None
     fresh = _FakeAuthClient.instances[0]
     assert fresh.send_2fa_calls == 0

--- a/tests/test_session_recovery.py
+++ b/tests/test_session_recovery.py
@@ -224,16 +224,18 @@ def test_authenticate_non_tty_email_prompt(
         authenticate(session_path)
 
 
-# --- 5. Non-TTY at 2FA-method prompt → InteractiveAuthRequired; session preserved ---
+# --- 5. Non-TTY, no mode set → defaults to SMS; session preserved ---
 
 
-def test_authenticate_non_tty_2fa_method_preserves_session(
+def test_authenticate_non_tty_no_mode_defaults_to_sms_preserves_session(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     env_creds: None,
 ) -> None:
-    """Regression guard for the InteractiveAuthRequired carve-out in the inner
-    retry: non-TTY at the 2FA-method prompt must NOT trigger session unlink."""
+    """With no EMPOWER_2FA_MODE and no TTY, authenticate defaults to SMS (the
+    only method Empower offers — there's no method prompt to block on),
+    dispatches the challenge, then raises InteractiveAuthRequired at the
+    verification-code prompt without unlinking the cached session."""
     session_path = tmp_path / "session.json"
     session_path.write_text("{}")
 
@@ -244,18 +246,17 @@ def test_authenticate_non_tty_2fa_method_preserves_session(
 
     _patch_input(monkeypatch, raise_eof)
 
-    with pytest.raises(InteractiveAuthRequired, match="EMPOWER_2FA_MODE"):
+    with pytest.raises(InteractiveAuthRequired, match="2FA verification cannot complete"):
         authenticate(session_path)
 
-    assert session_path.exists(), (
-        "non-TTY 2FA-method prompt must preserve the cached session "
-        "(the InteractiveAuthRequired carve-out)"
-    )
+    client = _FakeClient.instances[0]
+    assert client.send_2fa_modes == [TwoFactorMode.SMS]
+    assert session_path.exists(), "non-TTY at the code prompt must preserve the cached session"
     # Only one client — no retry occurred.
     assert len(_FakeClient.instances) == 1
 
 
-# --- 6. Non-TTY at verification-code prompt → InteractiveAuthRequired ---
+# --- 6. Non-TTY at verification-code prompt (explicit mode) → InteractiveAuthRequired ---
 
 
 def test_authenticate_non_tty_verify_code_prompt(
@@ -265,21 +266,14 @@ def test_authenticate_non_tty_verify_code_prompt(
 ) -> None:
     session_path = tmp_path / "session.json"
     session_path.write_text("{}")
+    monkeypatch.setenv("EMPOWER_2FA_MODE", "sms")
 
     _FakeClient.login_recipe = [TwoFactorRequiredError()]
 
-    # First input() call answers the 2FA-method prompt; the next one (code prompt) EOFs.
-    # _prompt() writes the message to stderr and calls input() without args, so we can't
-    # dispatch on prompt content — track call ordering with a queue instead.
-    answers = iter(["1"])
+    def raise_eof(_prompt: str = "") -> str:
+        raise EOFError
 
-    def queued_or_eof(_prompt: str = "") -> str:
-        try:
-            return next(answers)
-        except StopIteration:
-            raise EOFError from None
-
-    _patch_input(monkeypatch, queued_or_eof)
+    _patch_input(monkeypatch, raise_eof)
 
     with pytest.raises(InteractiveAuthRequired, match="2FA verification cannot complete"):
         authenticate(session_path)
@@ -554,7 +548,22 @@ def test_has_loaded_session_true_when_csrf_loaded(tmp_path: Path) -> None:
     from personalcapital2.client import EmpowerClient
 
     session_path = tmp_path / "session.json"
-    session_path.write_text(json.dumps({"csrf": "abc-123", "cookies": {"foo": "bar"}}))
+    session_path.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "csrf": "abc-123",
+                "cookies": [
+                    {
+                        "name": "foo",
+                        "value": "bar",
+                        "domain": ".empower-retirement.com",
+                        "path": "/",
+                    }
+                ],
+            }
+        )
+    )
     session_path.chmod(0o600)
     client = EmpowerClient(session_path=session_path)
     assert client.has_loaded_session is True
@@ -650,25 +659,29 @@ def test_authenticate_2fa_mode_env_sms(
     assert client.verify_2fa_modes == [TwoFactorMode.SMS]
 
 
-def test_authenticate_2fa_mode_env_email(
+def test_authenticate_2fa_mode_env_email_raises_tombstone(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     env_creds: None,
 ) -> None:
-    """EMPOWER_2FA_MODE=email dispatches via email."""
+    """EMPOWER_2FA_MODE=email raises a clear tombstone error — Empower removed
+    email 2FA server-side, so stale config is redirected to SMS rather than
+    silently dispatching a challenge that never arrives."""
     session_path = tmp_path / "session.json"
     session_path.write_text("{}")
     monkeypatch.setenv("EMPOWER_2FA_MODE", "email")
 
     _FakeClient.login_recipe = [TwoFactorRequiredError()]
-    answers = iter(["123456"])
-    _patch_input(monkeypatch, lambda _prompt="": next(answers))
+    # The tombstone error fires before any prompt; input() must not be reached.
+    _patch_input(monkeypatch, _input_must_not_be_called)
 
-    authenticate(session_path)
+    with pytest.raises(EmpowerAuthError) as exc_info:
+        authenticate(session_path)
 
-    client = _FakeClient.instances[0]
-    assert client.send_2fa_modes == [TwoFactorMode.EMAIL]
-    assert client.verify_2fa_modes == [TwoFactorMode.EMAIL]
+    assert type(exc_info.value) is EmpowerAuthError
+    msg = str(exc_info.value).lower()
+    assert "email" in msg
+    assert "sms" in msg
 
 
 def test_authenticate_2fa_mode_env_case_insensitive(
@@ -716,29 +729,29 @@ def test_authenticate_2fa_mode_env_invalid_raises_autherror(
     assert "carrier-pigeon" in str(exc_info.value)
 
 
-def test_authenticate_2fa_mode_env_empty_falls_through_to_prompt(
+def test_authenticate_2fa_mode_env_empty_defaults_to_sms(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     env_creds: None,
 ) -> None:
-    """Empty/whitespace EMPOWER_2FA_MODE is treated as unset — orchestrator
-    templating commonly produces empty env vars from missing upstream values.
-    Falls through to the interactive prompt; non-TTY there raises
-    InteractiveAuthRequired as usual.
+    """Empty/whitespace EMPOWER_2FA_MODE is treated as unset and defaults to
+    SMS — the only method Empower still offers. Orchestrator templating
+    commonly produces empty env vars from missing upstream values, and there's
+    no longer a method prompt to fall through to.
     """
     session_path = tmp_path / "session.json"
     session_path.write_text("{}")
     monkeypatch.setenv("EMPOWER_2FA_MODE", "   ")  # whitespace == unset
 
     _FakeClient.login_recipe = [TwoFactorRequiredError()]
+    answers = iter(["123456"])
+    _patch_input(monkeypatch, lambda _prompt="": next(answers))
 
-    def raise_eof(_prompt: str = "") -> str:
-        raise EOFError
+    authenticate(session_path)
 
-    _patch_input(monkeypatch, raise_eof)
-
-    with pytest.raises(InteractiveAuthRequired, match="EMPOWER_2FA_MODE"):
-        authenticate(session_path)
+    client = _FakeClient.instances[0]
+    assert client.send_2fa_modes == [TwoFactorMode.SMS]
+    assert client.verify_2fa_modes == [TwoFactorMode.SMS]
 
 
 def test_authenticate_2fa_mode_env_ignored_when_no_2fa_required(

--- a/uv.lock
+++ b/uv.lock
@@ -418,7 +418,7 @@ wheels = [
 
 [[package]]
 name = "personalcapital2"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },


### PR DESCRIPTION
## Summary

Two related auth fixes, plus a version bump to **0.4.0**.

### 1. Email 2FA removed (fixes #6)
Empower no longer offers email as a 2FA delivery method. The current login flow presents only **SMS** (and a voice call), and the legacy `challengeEmail` endpoint returns `success: true` while dispatching nothing — so selecting email blocked forever waiting for a code that never arrived. (Confirmed by driving the real login flow: the MFA screen lists only `OOB_SMS`/`OOB_PHONE`, and account settings expose no way to enable email or an authenticator app.)

- Removed `TwoFactorMode.EMAIL` and the interactive method-selection prompt.
- `EMPOWER_2FA_MODE` now accepts only `sms` and is optional (2FA defaults to SMS). A stale `email` value raises a clear `EmpowerAuthError` pointing to SMS instead of hanging.

### 2. "Session not authenticated" right after a successful login
Sessions were saved as a domain-less `{name: value}` cookie dump. On the next login a reloaded cookie no longer keyed identically to the fresh cookie the server set, so both lingered in the jar and the **stale one shadowed the fresh one** — Empower then rejected the first data call with `Session not authenticated`, even though `authenticatePassword` had just returned `SESSION_AUTHENTICATED`.

- `save_session`/`load_session` now persist each cookie's `domain`/`path`/`expires` and rebuild a fresh jar on load, so a fresh `Set-Cookie` overwrites the stale cookie by key.
- Old-format session files are ignored on load (the client re-authenticates once); the file is a short-lived cache, so no migration is performed.
- Side benefit: a remembered device now persists across runs instead of re-triggering 2FA every time.

### Misc
- Docs no longer claim a fixed "6-digit" code length (Empower's SMS code is shorter).

## Tests
- New: cookie round-trip preserves attributes; reloaded cookie is overwritten (not shadowed); old-format file is ignored.
- Updated: 2FA tests for SMS-only behavior and the `email` tombstone error.
- Full suite: 330 passing; ruff + pyright (strict) clean.

## Verification still worth doing live
Run `pc2 login` on this branch against a real account, then an immediate data command — it should succeed on the same run (previously failed), and a second invocation should reuse the session without re-prompting for 2FA.